### PR TITLE
feat: switch API to be promise-based

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 os: linux
 dist: xenial
 language: node_js
+# can't set this to production, because we don't want to add all of the
+# testing dependencies
+env: NODE_ENV=development
 node_js:
   - "lts/*"
 cache:

--- a/README.md
+++ b/README.md
@@ -4,13 +4,24 @@
 [![npm version](http://img.shields.io/npm/v/terminal-spawn.svg?style=flat)](https://npmjs.org/package/terminal-spawn 'View this project on npm')
 [![MIT license](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
-A library which wraps Node's [`child_process.spawn`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) to provide easy use of terminal commands.
+A library which wraps Node's [`child_process.spawn`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options)
+to provide easy use of terminal commands.
 
 It does this in an easy to use way by providing a nice interface on top of
-[`child_process.spawn`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) which allows you to call it exactly the same way as if
-you were running commands directly in the terminal.
+[`child_process.spawn`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options)
+which allows you to call it exactly the same way as
+if you were running commands directly in the terminal.
 
-I personally use this for running [gulp](https://github.com/gulpjs/gulp) tasks, since I got used to using npm scripts and their ability to directly run terminal commands very easily. Since it returns a [`ChildProcess`](https://nodejs.org/api/child_process.html#child_process_child_process) object, the result of calling [`child_process.spawn`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) [it can be directly used in gulp](https://gulpjs.com/docs/en/getting-started/async-completion#returning-a-child-process), see the [`gulpfile.babel.ts`](https://github.com/dbpiper/terminal-spawn/blob/master/gulpfile.babel.ts) in the project for an example.
+I personally use this for running [gulp](https://github.com/gulpjs/gulp) tasks,
+since I got used to using npm scripts and their ability to directly run terminal
+commands very easily. Since it returns a `Promise<SpawnSyncReturns<Buffer>>`,
+[it can be directly used in gulp](https://gulpjs.com/docs/en/getting-started/async-completion#returning-a-promise),
+see the [`gulpfile.babel.ts`](https://github.com/dbpiper/terminal-spawn/blob/master/gulpfile.babel.ts)
+in this project for an example.
+
+The project uses [TypeScript][typescript] and thus has types for it exported,
+so it works well in that environment. However, it also works just fine with
+vanilla JavaScript.
 
 ## Installation
 
@@ -20,28 +31,53 @@ I personally use this for running [gulp](https://github.com/gulpjs/gulp) tasks, 
 
 ## Usage
 
+### To just spawn a task if you don't need to know when it finishes
+
 ```typescript
 import terminalSpawn from 'terminal-spawn';
 
 terminalSpawn('echo "hello world!"');
 ```
 
+### To spawn a task and wait for it to complete, checking status code
+
+```typescript
+import terminalSpawn from 'terminal-spawn';
+
+// execute inside of IIAFE since we can't use top-level await
+(async () => {
+  const subprocess = await terminalSpawn('echo "hello world!"');
+
+  if (subprocess.status === 0) {
+    console.log('everything went well!');
+  } else {
+    console.warn('something went wrong!!!!');
+  }
+})();
+```
+
 ## API
 
 ### terminalSpawn(command, options)
 
-return type: [`ChildProcess`](https://nodejs.org/api/child_process.html#child_process_child_process)
+return type: `Promise<SpawnSyncReturns<Buffer>>`
 
 Executes the command inside of Node.js as if it were run in the shell. If
 command is an array then the commands will be run in series/sequentially.
 
+The result is a [`Promise`][promise] which has the same structure/type as the
+[return value of the synchronous version of `child_process.spawn`](spawn-sync-returns).
+
 ### terminalSpawnParallel(command, options)
 
-return type: [`ChildProcess`](https://nodejs.org/api/child_process.html#child_process_child_process)
+return type: `Promise<SpawnSyncReturns<Buffer>>`
 
 Executes the command inside of Node.js as if it were run in the shell, if
 command is an array then the commands will be run in parallel rather than
 in series/sequentially.
+
+The result is a [`Promise`][promise] which has the same structure/type as the
+[return value of the synchronous version of `child_process.spawn`](spawn-sync-returns).
 
 ### command
 
@@ -59,9 +95,9 @@ executed them in series, as if they were called with `&&` between them.
 
 type: `SpawnOptions`
 
-These are the options to pass to [`child_process.spawn`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options)
-they are the same as the [`spawn` options](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options)
-and are passed directly to [`child_process.spawn`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).
+These are the options to pass to [`child_process.spawn`][child_process.spawn]
+they are the same as the [`spawn` options][child_process.spawn]
+and are passed directly to [`child_process.spawn`][child_process.spawn].
 
 By default they are:
 
@@ -79,3 +115,8 @@ nice argument passing of terminalSpawn, e.g. `'echo "hello world!"` without
 ### License
 
 [MIT](https://github.com/dbpiper/terminal-spawn/blob/master/LICENSE) Copyright (c) [David Piper](https://github.com/dbpiper)
+
+[promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[spawn-sync-returns]: https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options
+[child_process.spawn]: https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options
+[typescript]: https://www.typescriptlang.org/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1363,10 +1363,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.11.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.1.tgz",
-      "integrity": "sha512-2azXFP9n4aA2QNLkKm/F9pzKxgYj1SMawZ5Eh9iC21RH3XNcFsivLVU2NhpMgQm7YobSByvIol4c42ZFusXFHQ==",
-      "dev": true
+      "version": "11.11.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.3.tgz",
+      "integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
     "prepublishOnly": "npm run build"
   },
   "types": "lib/index.d.ts",
-  "version": "1.1.0"
+  "version": "1.1.0",
+  "dependencies": {
+    "@types/node": "^11.11.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
     "url": "git+https://github.com/dbpiper/terminal-spawn.git"
   },
   "scripts": {
-    "build": "gulp build",
-    "lint": "gulp lint",
-    "preCommit": "gulp preCommit",
+    "build": "npx gulp build",
+    "lint": "npx gulp lint",
+    "preCommit": "npx gulp preCommit",
     "prepublishOnly": "npm run build"
   },
   "types": "lib/index.d.ts",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -3,70 +3,39 @@ import terminalSpawn, { terminalSpawnParallel } from '../index';
 describe('terminal-spawn tests', () => {
   describe('single command tests', () => {
     test('runs command and give exit code of zero', async () => {
-      const process = terminalSpawn('echo "hello world!"');
-      const processPromise = new Promise((resolve, _reject) => {
-        process.on('exit', code => {
-          const numCode = (code as unknown) as PromiseLike<number>;
-          resolve(numCode);
-        });
-      });
-      const exitCode = await processPromise;
-      expect(exitCode).toBe(0);
+      const subprocess = await terminalSpawn('echo "hello world!"');
+      expect(subprocess.status).toBe(0);
     });
 
     test('runs command and gives non-zero exit code', async () => {
       // the shell doesn't have a "blarg" command
-      const process = terminalSpawn('blarg "hello world!"');
-      const processPromise = new Promise((resolve, _reject) => {
-        process.on('exit', code => {
-          const numCode = (code as unknown) as PromiseLike<number>;
-          resolve(numCode);
-        });
-      });
-      const exitCode = await processPromise;
-      expect(exitCode).not.toBe(0);
+      const subprocess = await terminalSpawn('blarg "hello world!"');
+      expect(subprocess.status).not.toBe(0);
     });
   });
 
   describe('serial tests', () => {
     test('runs commands serially and give exit code of zero', async () => {
-      const process = terminalSpawn(['echo "hello "', 'echo "world!"']);
-      const processPromise = new Promise((resolve, _reject) => {
-        process.on('exit', code => {
-          const numCode = (code as unknown) as object;
-          resolve(numCode);
-        });
-      });
-      const exitCode = await processPromise;
-      expect(exitCode).toBe(0);
+      const subprocess = await terminalSpawn([
+        'echo "hello "',
+        'echo "world!"',
+      ]);
+      expect(subprocess.status).toBe(0);
     });
   });
 
   describe('parallel tests', () => {
     test('runs single command in parallel and give exit code of zero', async () => {
-      const process = terminalSpawnParallel(
-        'echo "hello world!"',
-      );
-      const processPromise = new Promise((resolve, _reject) => {
-        process.on('exit', code => {
-          const numCode = (code as unknown) as object;
-          resolve(numCode);
-        });
-      });
-      const exitCode = await processPromise;
-      expect(exitCode).toBe(0);
+      const subprocess = await terminalSpawnParallel('echo "hello world!"');
+      expect(subprocess.status).toBe(0);
     });
 
     test('runs commands in parallel and give exit code of zero', async () => {
-      const process = terminalSpawnParallel(['echo "hello "', 'echo "world!"']);
-      const processPromise = new Promise((resolve, _reject) => {
-        process.on('exit', code => {
-          const numCode = (code as unknown) as object;
-          resolve(numCode);
-        });
-      });
-      const exitCode = await processPromise;
-      expect(exitCode).toBe(0);
+      const subprocess = await terminalSpawnParallel([
+        'echo "hello "',
+        'echo "world!"',
+      ]);
+      expect(subprocess.status).toBe(0);
     });
   });
 });


### PR DESCRIPTION
BREAKING_CHANGE: Switch the API to be promise-based instead of just returning
the result of `spawn` (ChildProcess). This means that anything
depending on the result being a ChildProcess will need to be converted
to use the new API.