### PR TITLE
feat: make options easier to use by using defaults unless overwritten

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8772,9 +8772,9 @@
       }
     },
     "tslint-config-euclid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tslint-config-euclid/-/tslint-config-euclid-1.0.0.tgz",
-      "integrity": "sha512-uMpnbF6ILskHEYVhePM3y5fUA2ZVrGdnVWYEliiewY4ZaSGHr3Pwrr/qN99NDcVTf10tFuc3bOAu7KU6tyJ9Kg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tslint-config-euclid/-/tslint-config-euclid-1.1.1.tgz",
+      "integrity": "sha512-Yo9o87i8D2mbye6XJkGQ/DgCRWPOiQ2OvT1glhNZqZHmm50fcjHSZl5ualh7DIM//1EipFiCkodKmvaMZ3W+ww==",
       "dev": true,
       "requires": {
         "tslint-config-airbnb": "^5.11.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "jest": "^24.5.0",
     "ts-jest": "^24.0.0",
     "tslint": "^5.13.1",
-    "tslint-config-euclid": "1.0.0",
+    "tslint-config-euclid": "^1.1.1",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.3.3333",
     "typescript-tslint-plugin": "^0.3.1"

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -7,6 +7,13 @@ describe('terminal-spawn tests', () => {
       expect(subprocess.status).toBe(0);
     });
 
+    test('runs command in other directory and give exit code of zero', async () => {
+      const subprocess = await terminalSpawn('pwd', {
+        cwd: '/home',
+      });
+      expect(subprocess.status).toBe(0);
+    });
+
     test('runs command and gives non-zero exit code', async () => {
       // the shell doesn't have a "blarg" command
       const subprocess = await terminalSpawn('blarg "hello world!"');

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,11 @@ export type TerminalSpawn = (
  * Private Variables
  **************************************************************************** */
 
+const _spawnOptions: SpawnOptions = {
+  stdio: 'inherit',
+  shell: true,
+};
+
 const _spawnWithStringParser = (shellCommand: string) => {
   const shellCommandArray = shellCommand.split(' ');
   return {
@@ -26,11 +31,8 @@ const _spawnWithStringParser = (shellCommand: string) => {
 
 const _terminalSpawnPromiseWrapper = (
   command: Command,
-  options: SpawnOptions = {
-    stdio: 'inherit',
-    shell: true,
-  },
   spawnFunction: TerminalSpawn,
+  options?: SpawnOptions,
 ) =>
   new Promise<SpawnPromiseReturns>((resolve, _reject) => {
     const subprocess = spawnFunction(command, options);
@@ -79,10 +81,7 @@ const _terminalSpawnPromiseWrapper = (
 
 const _terminalSpawnProcess: TerminalSpawn = (
   command: Command,
-  options: SpawnOptions = {
-    stdio: 'inherit',
-    shell: true,
-  },
+  options?: SpawnOptions,
 ) => {
   let terminalCommand = '';
   if (Array.isArray(command)) {
@@ -91,15 +90,13 @@ const _terminalSpawnProcess: TerminalSpawn = (
     terminalCommand = command as string;
   }
   const commandObj = _spawnWithStringParser(terminalCommand);
-  return spawn(commandObj.command, commandObj.args, options);
+  const spawnOptions: SpawnOptions = { ..._spawnOptions, ...options };
+  return spawn(commandObj.command, commandObj.args, spawnOptions);
 };
 
 const _terminalSpawnParallelProcess: TerminalSpawn = (
   command: Command,
-  options: SpawnOptions = {
-    stdio: 'inherit',
-    shell: true,
-  },
+  options?: SpawnOptions,
 ) => {
   let terminalCommand = '';
   if (Array.isArray(command)) {
@@ -109,29 +106,19 @@ const _terminalSpawnParallelProcess: TerminalSpawn = (
     terminalCommand = command as string;
   }
   const commandObj = _spawnWithStringParser(terminalCommand);
-  return spawn(commandObj.command, commandObj.args, options);
+  const spawnOptions: SpawnOptions = { ..._spawnOptions, ...options };
+  return spawn(commandObj.command, commandObj.args, spawnOptions);
 };
 
 /* *****************************************************************************
  * Public Variables
  **************************************************************************** */
 
-const terminalSpawn = (
-  command: Command,
-  options: SpawnOptions = {
-    stdio: 'inherit',
-    shell: true,
-  },
-) => _terminalSpawnPromiseWrapper(command, options, _terminalSpawnProcess);
+const terminalSpawn = (command: Command, options?: SpawnOptions) =>
+  _terminalSpawnPromiseWrapper(command, _terminalSpawnProcess, options);
 
-const terminalSpawnParallel = (
-  command: Command,
-  options: SpawnOptions = {
-    stdio: 'inherit',
-    shell: true,
-  },
-) =>
-  _terminalSpawnPromiseWrapper(command, options, _terminalSpawnParallelProcess);
+const terminalSpawnParallel = (command: Command, options?: SpawnOptions) =>
+  _terminalSpawnPromiseWrapper(command, _terminalSpawnParallelProcess, options);
 
 export default terminalSpawn;
 


### PR DESCRIPTION
The options the user specifies now get combined with the default
options, rather than always replacing them, this means that the
user can specify *additional* options and still keep the default
options in-place. Practically, this means that the user doesn't
have to specify things like `shell: true` every-time they want
to use something like `cwd`.