### PR TITLE
fix: resolve design issue with 2.0.0 being unable to kill process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2019-03-15
+
+### Fixed
+
+- Resolved some design issues with [2.0.0], namely the fact that it lacked
+  the ability to close processes that don't close on their own. The API
+  now returns _both_ the reference to the process, which can be killed, and
+  the promise added in [2.0.0]. This means that you can now kill the process with
+  its respective object, and then await the promise and check its signal to ensure
+  termination.
+
 ## [2.0.0] - 2019-03-14
 
 ### Changed
@@ -41,7 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Created the basic project, which allows spawning of terminal commands.
 
-[unreleased]: https://github.com/dbpiper/terminal-spawn/compare/2.0.0...HEAD
+[unreleased]: https://github.com/dbpiper/terminal-spawn/compare/2.0.1...HEAD
+[2.0.1]: https://github.com/dbpiper/terminal-spawn/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/dbpiper/terminal-spawn/compare/1.1.0...2.0.0
 [1.1.0]: https://github.com/dbpiper/terminal-spawn/compare/1.0.1...1.1.0
 [1.0.1]: https://github.com/dbpiper/terminal-spawn/compare/1.0.0...1.0.1

--- a/gulpfile.babel.ts
+++ b/gulpfile.babel.ts
@@ -1,7 +1,7 @@
 import { parallel, series } from 'gulp';
 import terminalSpawn from './src';
 
-const checkTypes = () => terminalSpawn('npx tsc -p "./tsconfig.json"');
+const checkTypes = () => terminalSpawn('npx tsc -p "./tsconfig.json"').promise;
 
 const lintTS = () => {
   const rootFiles = '"./*.ts?(x)"';
@@ -10,27 +10,28 @@ const lintTS = () => {
   const tsconfig = '--project tsconfig.json';
   return terminalSpawn(
     `npx tslint ${rootFiles} ${srcFiles} ${configFiles} ${tsconfig}`,
-  );
+  ).promise;
 };
 
 const lint = lintTS;
 
-const test = () => terminalSpawn('npx jest');
+const test = () => terminalSpawn('npx jest').promise;
 
 const staticCheck = series(lint, checkTypes);
 
 const staticCheckAndTest = series(staticCheck, test);
 
 const buildJs = () =>
-  terminalSpawn(`npx babel src --out-dir lib --extensions ".ts"`);
+  terminalSpawn(`npx babel src --out-dir lib --extensions ".ts"`).promise;
 
-const buildTypes = () => terminalSpawn('npx tsc');
+const buildTypes = () => terminalSpawn('npx tsc').promise;
 
 const build = parallel(buildJs, buildTypes);
 
-const gitStatus = () => terminalSpawn('npx git status');
+const gitStatus = () => terminalSpawn('npx git status').promise;
 
-const sleep = (seconds: number = 0) => terminalSpawn(`sleep ${seconds}`);
+const sleep = (seconds: number = 0) =>
+  terminalSpawn(`sleep ${seconds}`).promise;
 
 const sleepForReview = () => {
   // giving 4 seconds to review the git commit status

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "terminal-spawn",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "prepublishOnly": "npm run build"
   },
   "types": "lib/index.d.ts",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "dependencies": {
     "@types/node": "^11.11.3"
   }

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -3,37 +3,56 @@ import terminalSpawn, { terminalSpawnParallel } from '../index';
 describe('terminal-spawn tests', () => {
   describe('single command tests', () => {
     test('runs command and give exit code of zero', async () => {
-      const subprocess = await terminalSpawn('echo "hello world!"');
+      const subprocess = await terminalSpawn('echo "hello world!"').promise;
       expect(subprocess.status).toBe(0);
+    });
+
+    test('runs command that never ends, is killed and give exit code of zero', async () => {
+      const subprocessSpawn = terminalSpawn(`
+        while true
+        do
+          echo "hello world!"
+          sleep 0.25
+        done
+      `);
+      // wait for 500 ms to pass...
+      const timeToWait = 500;
+      await new Promise((resolve, _reject) =>
+        setTimeout(() => {
+          resolve();
+        }, timeToWait)
+      );
+      subprocessSpawn.process.kill();
+      const subprocess = await subprocessSpawn.promise;
+      expect(subprocess.signal).toEqual('SIGTERM');
     });
 
     test('runs command in other directory and give exit code of zero', async () => {
       const subprocess = await terminalSpawn('pwd', {
         cwd: '/home',
-      });
+      }).promise;
       expect(subprocess.status).toBe(0);
     });
 
     test('runs command and gives non-zero exit code', async () => {
       // the shell doesn't have a "blarg" command
-      const subprocess = await terminalSpawn('blarg "hello world!"');
+      const subprocess = await terminalSpawn('blarg "hello world!"').promise;
       expect(subprocess.status).not.toBe(0);
     });
   });
 
   describe('serial tests', () => {
     test('runs commands serially and give exit code of zero', async () => {
-      const subprocess = await terminalSpawn([
-        'echo "hello "',
-        'echo "world!"',
-      ]);
+      const subprocess = await terminalSpawn(['echo "hello "', 'echo "world!"'])
+        .promise;
       expect(subprocess.status).toBe(0);
     });
   });
 
   describe('parallel tests', () => {
     test('runs single command in parallel and give exit code of zero', async () => {
-      const subprocess = await terminalSpawnParallel('echo "hello world!"');
+      const subprocess = await terminalSpawnParallel('echo "hello world!"')
+        .promise;
       expect(subprocess.status).toBe(0);
     });
 
@@ -41,7 +60,7 @@ describe('terminal-spawn tests', () => {
       const subprocess = await terminalSpawnParallel([
         'echo "hello "',
         'echo "world!"',
-      ]);
+      ]).promise;
       expect(subprocess.status).toBe(0);
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,124 +1,41 @@
+import { ChildProcess, SpawnOptions, SpawnSyncReturns } from 'child_process';
 import {
-  ChildProcess,
-  spawn,
-  SpawnOptions,
-  SpawnSyncReturns,
-} from 'child_process';
+  terminalSpawnParallelProcess,
+  terminalSpawnProcess,
+  terminalSpawnPromiseWrapper,
+} from './util';
 
-export type SpawnPromiseReturns = SpawnSyncReturns<Buffer>;
+export type SpawnPromiseReturns = Promise<SpawnSyncReturns<Buffer>>;
 export type Command = string | string[];
-export type TerminalSpawn = (
+
+export interface TerminalSpawnReturns {
+  process: ChildProcess;
+  promise: SpawnPromiseReturns;
+}
+
+const terminalSpawn = (
   command: Command,
   options?: SpawnOptions,
-) => ChildProcess;
-
-/* *****************************************************************************
- * Private Variables
- **************************************************************************** */
-
-const _spawnOptions: SpawnOptions = {
-  stdio: 'inherit',
-  shell: true,
-};
-
-const _spawnWithStringParser = (shellCommand: string) => {
-  const shellCommandArray = shellCommand.split(' ');
+): TerminalSpawnReturns => {
+  const subprocess = terminalSpawnProcess(command, options);
+  const promise = terminalSpawnPromiseWrapper(subprocess);
   return {
-    command: shellCommandArray[0],
-    args: shellCommandArray.slice(1),
+    promise,
+    process: subprocess,
   };
 };
 
-const _terminalSpawnPromiseWrapper = (
-  command: Command,
-  spawnFunction: TerminalSpawn,
-  options?: SpawnOptions,
-) =>
-  new Promise<SpawnPromiseReturns>((resolve, _reject) => {
-    const subprocess = spawnFunction(command, options);
-    let stdin = '';
-    let stdout = '';
-    let stderr = '';
-    let error = {
-      name: '',
-      message: '',
-    };
-
-    if (subprocess.stdin) {
-      subprocess.stdin.on('data', (chunk: Buffer) => {
-        stdin += chunk.toString();
-      });
-    }
-
-    if (subprocess.stdout) {
-      subprocess.stdout.on('data', (chunk: Buffer) => {
-        stdout += chunk.toString();
-      });
-    }
-
-    if (subprocess.stderr) {
-      subprocess.stderr.on('data', (chunk: Buffer) => {
-        stderr += chunk.toString();
-      });
-    }
-
-    subprocess.on('error', (err: Error) => {
-      error = err;
-    });
-
-    subprocess.on('close', (code: number, signal: string) => {
-      resolve({
-        error,
-        signal,
-        pid: process.pid,
-        output: [stdin, stdout, stderr],
-        stdout: Buffer.from(stdout),
-        stderr: Buffer.from(stderr),
-        status: code,
-      });
-    });
-  });
-
-const _terminalSpawnProcess: TerminalSpawn = (
+const terminalSpawnParallel = (
   command: Command,
   options?: SpawnOptions,
-) => {
-  let terminalCommand = '';
-  if (Array.isArray(command)) {
-    terminalCommand = command.join(' && ');
-  } else {
-    terminalCommand = command as string;
-  }
-  const commandObj = _spawnWithStringParser(terminalCommand);
-  const spawnOptions: SpawnOptions = { ..._spawnOptions, ...options };
-  return spawn(commandObj.command, commandObj.args, spawnOptions);
+): TerminalSpawnReturns => {
+  const subprocess = terminalSpawnParallelProcess(command, options);
+  const promise = terminalSpawnPromiseWrapper(subprocess);
+  return {
+    promise,
+    process: subprocess,
+  };
 };
-
-const _terminalSpawnParallelProcess: TerminalSpawn = (
-  command: Command,
-  options?: SpawnOptions,
-) => {
-  let terminalCommand = '';
-  if (Array.isArray(command)) {
-    terminalCommand = command.join(' & ');
-    terminalCommand += '; wait';
-  } else {
-    terminalCommand = command as string;
-  }
-  const commandObj = _spawnWithStringParser(terminalCommand);
-  const spawnOptions: SpawnOptions = { ..._spawnOptions, ...options };
-  return spawn(commandObj.command, commandObj.args, spawnOptions);
-};
-
-/* *****************************************************************************
- * Public Variables
- **************************************************************************** */
-
-const terminalSpawn = (command: Command, options?: SpawnOptions) =>
-  _terminalSpawnPromiseWrapper(command, _terminalSpawnProcess, options);
-
-const terminalSpawnParallel = (command: Command, options?: SpawnOptions) =>
-  _terminalSpawnPromiseWrapper(command, _terminalSpawnParallelProcess, options);
 
 export default terminalSpawn;
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,117 @@
+import {
+  ChildProcess,
+  spawn,
+  SpawnOptions,
+  SpawnSyncReturns,
+} from 'child_process';
+import { Command, SpawnPromiseReturns } from './index';
+
+type TerminalSpawnProcess = (
+  command: Command,
+  options?: SpawnOptions,
+) => ChildProcess;
+
+/* *****************************************************************************
+ * Private Variables
+ **************************************************************************** */
+
+const _spawnOptions: SpawnOptions = {
+  stdio: 'inherit',
+  shell: true,
+};
+
+const _spawnWithStringParser = (shellCommand: string) => {
+  const shellCommandArray = shellCommand.split(' ');
+  return {
+    command: shellCommandArray[0],
+    args: shellCommandArray.slice(1),
+  };
+};
+
+/* *****************************************************************************
+ * Public Variables
+ **************************************************************************** */
+
+const terminalSpawnPromiseWrapper = (
+  subprocess: ChildProcess,
+): SpawnPromiseReturns =>
+  new Promise<SpawnSyncReturns<Buffer>>((resolve, _reject) => {
+    let stdin = '';
+    let stdout = '';
+    let stderr = '';
+    let error = {
+      name: '',
+      message: '',
+    };
+
+    if (subprocess.stdin) {
+      subprocess.stdin.on('data', (chunk: Buffer) => {
+        stdin += chunk.toString();
+      });
+    }
+
+    if (subprocess.stdout) {
+      subprocess.stdout.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString();
+      });
+    }
+
+    if (subprocess.stderr) {
+      subprocess.stderr.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+    }
+
+    subprocess.on('error', (err: Error) => {
+      error = err;
+    });
+
+    subprocess.on('close', (code: number, signal: string) => {
+      resolve({
+        error,
+        signal,
+        pid: process.pid,
+        output: [stdin, stdout, stderr],
+        stdout: Buffer.from(stdout),
+        stderr: Buffer.from(stderr),
+        status: code,
+      });
+    });
+  });
+
+const terminalSpawnProcess: TerminalSpawnProcess = (
+  command: Command,
+  options?: SpawnOptions,
+) => {
+  let terminalCommand = '';
+  if (Array.isArray(command)) {
+    terminalCommand = command.join(' && ');
+  } else {
+    terminalCommand = command as string;
+  }
+  const commandObj = _spawnWithStringParser(terminalCommand);
+  const spawnOptions: SpawnOptions = { ..._spawnOptions, ...options };
+  return spawn(commandObj.command, commandObj.args, spawnOptions);
+};
+
+const terminalSpawnParallelProcess: TerminalSpawnProcess = (
+  command: Command,
+  options?: SpawnOptions,
+) => {
+  let terminalCommand = '';
+  if (Array.isArray(command)) {
+    terminalCommand = command.join(' & ');
+    terminalCommand += '; wait';
+  } else {
+    terminalCommand = command as string;
+  }
+  const commandObj = _spawnWithStringParser(terminalCommand);
+  const spawnOptions: SpawnOptions = { ..._spawnOptions, ...options };
+  return spawn(commandObj.command, commandObj.args, spawnOptions);
+};
+
+export {
+  terminalSpawnPromiseWrapper,
+  terminalSpawnParallelProcess,
+  terminalSpawnProcess,
+};


### PR DESCRIPTION
Resolve a design issue in 2.0.0 where the process that was spawned could
not be killed. This happened because we started _only_ returning the
promise, which meant that things worked fine for processes that
terminated on their own, but not for processes that never terminated
on their own. Such as a server that needs to be explicitly killed.